### PR TITLE
default config: use 'enter' to 'confirm'

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -153,6 +153,7 @@ impl std::default::Default for RsMixerConfig {
         bindings.insert("shift+tab".to_string(), "cycle_pages_backward".to_string());
 
         bindings.insert("enter".to_string(), "context_menu".to_string());
+        bindings.insert("enter".to_string(), "confirm".to_string());
         bindings.insert("esc".to_string(), "close_context_menu".to_string());
         bindings.insert("q".to_string(), "close_context_menu".to_string());
 


### PR DESCRIPTION
Otherwise, there is no way to positively close popups with the default
key bindings.

---

To test, remove your rsmixer config, press Enter and try to suspend the card. Unlike before (ie. after removing the rsmixer config and then running rsmixer), a second press of Enter actually suspends the card. Previously, it did nothing, and only `q` got you back out.