### PR TITLE
Fix compilation warning

### DIFF
--- a/src/pa/pa_interface.rs
+++ b/src/pa/pa_interface.rs
@@ -35,7 +35,7 @@ pub fn start(
 	debug!("[PAInterface] Creating new context");
 	let context = Rc::new(RefCell::new(
 		match PAContext::new_with_proplist(
-			mainloop.borrow_mut().deref().deref(),
+			mainloop.borrow_mut().deref(),
 			"RsMixerContext",
 			&proplist,
 		) {


### PR DESCRIPTION
warning: call to `.deref()` on a reference in this situation does nothing
  --> src/pa/pa_interface.rs:38:33
   |
38 |             mainloop.borrow_mut().deref().deref(),
   |                                          ^^^^^^^^ help: remove this redundant call
   |
   = note: the type `pulse::mainloop::threaded::Mainloop` does not implement `Deref`, so calling `deref` on `&pulse::mainloop::threaded::Mainloop` copies the reference, which does not do anything and can be removed
   = note: `#[warn(noop_method_call)]` on by default